### PR TITLE
Allow installer to set slot user

### DIFF
--- a/config.d/23-SlotUser
+++ b/config.d/23-SlotUser
@@ -1,1 +1,1 @@
-SlotUser = changeme
+SlotUser = nobody

--- a/config.d/23-SlotUser
+++ b/config.d/23-SlotUser
@@ -1,0 +1,1 @@
+SlotUser = changeme

--- a/config.d/30-Startd
+++ b/config.d/30-Startd
@@ -1,11 +1,15 @@
 use ROLE : Execute
-use FEATURE : PartitionableSlot
 
 # Jobs must have IS_TRANSFER_JOB = true
 START = TARGET.IS_TRANSFER_JOB
 
-# Jobs should target UniqueName
-STARTD_ATTRS = $(STARTD_ATTRS), UniqueName, InstallUser, DataDir
+# Advertise information about install and machine
+STARTD_ATTRS = $(STARTD_ATTRS), UniqueName, InstallUser, DataDir, SlotUser
 
 # Jobs may not run as owner
 STARTER_ALLOW_RUNAS_OWNER = False
+
+# Single slot, runs as SlotUser
+SLOT_TYPE_1 = 100%
+NUM_SLOTS_TYPE_1 = 1
+SLOT1_USER = $(SlotUser)

--- a/install_htcondor.sh
+++ b/install_htcondor.sh
@@ -260,10 +260,11 @@ elif [[ "$USER" != "$SLOTUSER" && "$SLOTUSER" != "nobody" ]]; then
     $SUDO usermod -a -G "$SHARED_GROUP" "$SLOTUSER" || fail "Could not add $SLOTUSER to $SHARED_GROUP group"
 
     # Set group permissions on data source directory
-    chgrp -Rc "$SHARED_GROUP" "$DATA_SOURCE_DIRECTORY" >&19 2>&19 || fail "Could not set $SHARED_GROUP group ownership on $DATA_SOURCE_DIRECTORY"
-    chmod g+srwx "$DATA_SOURCE_DIRECTORY" || fail "Could not set permissions on $DATA_SOURCE_DIRECTORY"
-    find "$DATA_SOURCE_DIRECTORY" -type d -exec chmod g+srwx "{}" \; || fail "Could not set permissions on $DATA_SOURCE_DIRECTORY subdirectories"
-    find "$DATA_SOURCE_DIRECTORY" -type f -exec chmod g+r "{}" \; || fail "Could not set permissions on $DATA_SOURCE_DIRECTORY files"
+    # (using sudo because don't want to logout/login for new group)
+    $SUDO chgrp -Rc "$SHARED_GROUP" "$DATA_SOURCE_DIRECTORY" >&19 2>&19 || fail "Could not set $SHARED_GROUP group ownership on $DATA_SOURCE_DIRECTORY"
+    $SUDO chmod g+srwx "$DATA_SOURCE_DIRECTORY" || fail "Could not set permissions on $DATA_SOURCE_DIRECTORY"
+    $SUDO find "$DATA_SOURCE_DIRECTORY" -type d -exec chmod g+srwx "{}" \; || fail "Could not set permissions on $DATA_SOURCE_DIRECTORY subdirectories"
+    $SUDO find "$DATA_SOURCE_DIRECTORY" -type f -exec chmod g+r "{}" \; || fail "Could not set permissions on $DATA_SOURCE_DIRECTORY files"
 
 elif [[ "$SLOTUSER" == "nobody" ]]; then
     echo "Setting permissions on $DATA_SOURCE_DIRECTORY to be read-only by HTCondor..."

--- a/install_htcondor.sh
+++ b/install_htcondor.sh
@@ -128,7 +128,7 @@ while [[ -z "$SLOTUSER" ]]; do
     [[ -z "$SLOTUSER" ]] && [[ ! -z "$DEFAULT_SLOTUSER" ]] && \
 	SLOTUSER="$DEFAULT_SLOTUSER"
 done
-if [[ "$SLOTUSER" == "root" ]]; do
+if [[ "$SLOTUSER" == "root" ]]; then
     fail_noexit "Transfer jobs cannot run as root"
     echo "Please check your input and try again" 1>&2
     exit 1

--- a/install_htcondor.sh
+++ b/install_htcondor.sh
@@ -26,7 +26,7 @@ warn() {
     echo "WARNING:     $*" 1>&2
 }
 
-while getopts "c:d:n:" OPTION; do
+while getopts "c:d:n:u:" OPTION; do
     case "$OPTION" in
 	c)
 	    CENTRAL_MANAGER="$OPTARG"


### PR DESCRIPTION
1. Modifies the execute node config to use a single slot with all resources, and make that slot run as user `$(SlotUser)` defined in `23-SlotUser` (default `nobody`).

2. Adds new option to `install_htcondor.sh` to set the slot user, defaulting to `$USER`.

With this new option, `install_htcondor.sh` no longer sets permissions on the data source directory _unless_:
1. `$USER` is root, in which case gives full permissions/ownership to the slot user, or
2. `$SLOTUSER` is nobody, in which case give readonly permissions to others, or
3. `$SLOTUSER` is different from `$USER`, in which case add both to a group (`xferusers`) and give full group permissions/ownership to both users.